### PR TITLE
Fix too many open files error by deleting temp file

### DIFF
--- a/lib/REST/Neo4p/Query.pm
+++ b/lib/REST/Neo4p/Query.pm
@@ -439,6 +439,7 @@ sub _process_row {
 sub finish {
   my $self = shift;
   delete $self->{_iterator};
+  unlink $self->tmpf->filename if ($self->tmpf);
   delete $self->{_tempfile};
   return 1;
 }


### PR DESCRIPTION
By not waiting on the garbage collector and unlinking the file ourselves the issue of too many files open is fixed.
