### PR TITLE
Prepend "Basic " to Authorization Headers

### DIFF
--- a/lib/REST/Neo4p/Agent/HTTP/Thin.pm
+++ b/lib/REST/Neo4p/Agent/HTTP/Thin.pm
@@ -3,7 +3,7 @@ use v5.10;
 package REST::Neo4p::Agent::HTTP::Thin;
 use base qw/HTTP::Thin REST::Neo4p::Agent/;
 use URI::Escape;
-use MIME::Base64;
+use LWP::Authen::Basic;
 use REST::Neo4p::Exceptions;
 use strict;
 use warnings;
@@ -26,7 +26,9 @@ sub credentials {
   $self->{_user} = $user;
   $self->{_pwd} = $pwd;
   if ($user && $pwd) {
-    $self->default_header('Authorization' => encode_base64("$user:$pwd",''));
+    $self->default_header(
+      Authorization => LWP::Authen::Basic->auth_header($user, $pass)
+    );
   }
   1;
 }

--- a/lib/REST/Neo4p/Agent/HTTP/Thin.pm
+++ b/lib/REST/Neo4p/Agent/HTTP/Thin.pm
@@ -3,13 +3,12 @@ use v5.10;
 package REST::Neo4p::Agent::HTTP::Thin;
 use base qw/HTTP::Thin REST::Neo4p::Agent/;
 use URI::Escape;
-use LWP::Authen::Basic;
+use MIME::Base64;
 use REST::Neo4p::Exceptions;
 use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::Agent::HTTP::Thin::VERSION = 0.3012;
   $REST::Neo4p::Agent::HTTP::Thin::VERSION = 0.3012;
 }
 
@@ -27,7 +26,7 @@ sub credentials {
   $self->{_pwd} = $pwd;
   if ($user && $pwd) {
     $self->default_header(
-      Authorization => LWP::Authen::Basic->auth_header($user, $pass)
+      'Authorization' => "Basic " . encode_base64("$user:$pwd", '')
     );
   }
   1;

--- a/lib/REST/Neo4p/Agent/LWP/UserAgent.pm
+++ b/lib/REST/Neo4p/Agent/LWP/UserAgent.pm
@@ -1,11 +1,10 @@
 #$Id$
 package REST::Neo4p::Agent::LWP::UserAgent;
 use base qw/LWP::UserAgent REST::Neo4p::Agent/;
-use MIME::Base64;
+use LWP::Authen::Basic;
 use strict;
 use warnings;
 BEGIN {
-  $REST::Neo4p::Agent::LWP::UserAgent::VERSION = "0.3012";
   $REST::Neo4p::Agent::LWP::UserAgent::VERSION = "0.3012";
 }
 sub new {
@@ -19,8 +18,9 @@ sub credentials {
   my $self = shift;
   my ($host, $realm, $user, $pass) = @_;
   if ($user && $pass) {
-    $self->default_header( 'Authorization' => encode_base64("$user:$pass",'') )
+    $self->default_header(
+      Authorization => LWP::Authen::Basic->auth_header($user, $pass)
+    );
   }
 }
 1;
-


### PR DESCRIPTION
I found that the Authorization header needs to be prepended with "Basic " to work with graphenedb.  The Mojo::UserAgent implementation already does this, so this PR brings the other two agent types to that standard.
