### PR TITLE
Fix Relationship constructor to not die

### DIFF
--- a/lib/REST/Neo4p/Relationship.pm
+++ b/lib/REST/Neo4p/Relationship.pm
@@ -13,8 +13,8 @@ BEGIN {
 sub new {
   my $self = shift;
   my ($from_node, $to_node, $type, $rel_props) = @_;
-  unless (ref $from_node && $from_node->is_a('REST::Neo4p::Node') &&
-	  ref $to_node && $to_node->is_a('REST::Neo4p::Node') &&
+  unless (ref $from_node && $from_node->isa('REST::Neo4p::Node') &&
+	  ref $to_node && $to_node->isa('REST::Neo4p::Node') &&
 	  defined $type) {
     REST::Neo4p::LocalException->throw("Requires 2 REST::Neo4p::Node objects and a relationship type\n");
   }
@@ -68,7 +68,7 @@ REST::Neo4p::Relationship - Neo4j relationship object
 
 =head1 SYNOPSIS
 
- $n1 = REST::Neo4p::Node->new( {name => 'Harry'} )
+ $n1 = REST::Neo4p::Node->new( {name => 'Harry'} );
  $n2 = REST::Neo4p::Node->new( {name => 'Sally'} );
  $r1 = $n1->relate_to($n2, 'met');
  $r1->set_property({ when => 'July' });

--- a/t/relationship_new.t
+++ b/t/relationship_new.t
@@ -1,0 +1,73 @@
+#-*-perl-*-
+use Test::More;
+use Module::Build;
+use lib '../lib';
+use lib 't/lib';
+use Neo4p::Connect;
+use strict;
+use warnings;
+no warnings qw(once);
+my @cleanup;
+use_ok('REST::Neo4p');
+
+my $build;
+my ($user,$pass);
+
+eval {
+  $build = Module::Build->current;
+  $user = $build->notes('user');
+  $pass = $build->notes('pass');
+};
+
+my $TEST_SERVER = $build ? $build->notes('test_server') : 'http://127.0.0.1:7474';
+my $num_live_tests = 1;
+
+my $not_connected = connect($TEST_SERVER,$user,$pass);
+diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
+
+
+SKIP : {
+  skip 'no local connection to neo4j', $num_live_tests if $not_connected;
+
+  # example code from the REST::Neo4p::Relationship synposis:
+
+  my $n1 = REST::Neo4p::Node->new( {name => 'Harry'} );
+  my $n2 = REST::Neo4p::Node->new( {name => 'Sally'} );
+  ok $n1, 'Harry' and push @cleanup, $n1;
+  ok $n2, 'Sally' and push @cleanup, $n2;
+  my $r1 = $n1->relate_to($n2, 'met');
+  ok $r1, 'met' and push @cleanup, $r1;
+  $r1->set_property({ when => 'July' });
+
+  my $r2;
+  eval { $r2 = REST::Neo4p::Relationship->new( $n2 => $n1, 'dropped' ); };
+  ok $r2, 'dropped' and push @cleanup, $r2;
+
+
+  # more checks
+
+  my ($r3, $r4, $r5, $r6, $r7);
+  eval { $r3 = REST::Neo4p::Relationship->new( $n1 => $r1, 'fails' ); };
+  isa_ok $@, 'REST::Neo4p::LocalException', '(node)-->[relationship]';
+  eval { $r4 = REST::Neo4p::Relationship->new( $r1 => $n1, 'fails' ); };
+  isa_ok $@, 'REST::Neo4p::LocalException', '[relationship]-->(node)';
+  eval { $r5 = REST::Neo4p::Relationship->new( $n1 => undef, 'fails' ); };
+  isa_ok $@, 'REST::Neo4p::LocalException', '(node)-->null';
+  eval { $r6 = REST::Neo4p::Relationship->new( undef => $n1, 'fails' ); };
+  isa_ok $@, 'REST::Neo4p::LocalException', 'null-->(node)';
+  eval { $r7 = REST::Neo4p::Relationship->new( $n1 => $n1, 'selfref' ); };
+  ok $r7, 'selfref';
+  push @cleanup, ($r3, $r4, $r5, $r6, $r7);
+
+
+  1;
+
+}
+
+
+END {
+  CLEANUP : {
+    ok $_->remove, 'entity removed' for reverse grep {ref $_ && $_->can('remove')} @cleanup;
+  }
+  done_testing;
+}


### PR DESCRIPTION
Hi Mark, I discovered that running the code example from the `REST::Neo4p::Relationship` POD synopsis results in a Perl run-time error:

`Can't locate object method "is_a" via package "REST::Neo4p::Node" at lib/REST/Neo4p/Relationship.pm line 16.`

This pull request attempts to fix that. It also includes some simple tests for the constructor and fixes a minor typo in the code example.