### PR TITLE
Added keep-alive support for default LWP UserAgent.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,6 @@ nytprof.out
 *.o
 *.bs
 nytprof*
+.idea
+*.iml
 /**/*~

--- a/lib/REST/Neo4p/Agent/LWP/UserAgent.pm
+++ b/lib/REST/Neo4p/Agent/LWP/UserAgent.pm
@@ -2,6 +2,7 @@
 package REST::Neo4p::Agent::LWP::UserAgent;
 use base qw/LWP::UserAgent REST::Neo4p::Agent/;
 use LWP::Authen::Basic;
+use LWP::ConnCache;
 use strict;
 use warnings;
 BEGIN {
@@ -10,6 +11,13 @@ BEGIN {
 sub new {
   my ($class,@args) = @_;
   my $self = $class->SUPER::new(@_);
+  #This really helps server not to be blown by TIME_WAIT'ed sockets.
+  #If load is high - even if 1 thread is used -
+  #with disabled keep-alive sockets are screwed on the server side.
+  my $cache = LWP::ConnCache->new;
+  #TODO FIXME This number should be configurable in some comfortable way
+  $cache->total_capacity([30]);
+  $self->conn_cache($cache);
   return $self;
 }
 sub add_header { shift->default_headers->header(@_) }


### PR DESCRIPTION
Server side is overwhelmed by TIME_WAIT'ing sockets because of this wasn't enabled.
Because of this driver creates connection for EVERY microaction, even setting single attribute to node is a single connection.
Long-running actions with driver, for example, if you making some loading to neo4j server, and continuously accessing server,
even one thread generates so many connections, that after some time it stumble upon an obstacle:
it should wait for a server is freeing some connection to accept new connection from client.
This bottleneck has some conditions, such as the intensity of sending requests, and the tuning of the network protocol in the OS on the server.