### PR TITLE
Minor issues with id roundtrip and UTF-8

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 Revision history for Perl module REST::Neo4p
+
+0.3021 2018-04-24
+    - Enable UTF-8 decoding of query responses
+
 0.3020 2017-07-01
     - Update Mojo::Message::Response usage to fix failing tests
 0.3012 2015-11-06

--- a/MANIFEST
+++ b/MANIFEST
@@ -55,7 +55,10 @@ t/agent_mod.t
 t/lib/Neo4p/Connect.pm
 t/lib/Neo4p/Test.pm
 t/lib/Neo4p/TestAgent.pm
+t/id_roundtrip.t
 t/issue_5.t
+t/json_utf8.t
+t/relationship_new.t
 t/rt_80150.t
 t/rt_80196.t
 t/rt_80471.t

--- a/lib/REST/Neo4p.pm
+++ b/lib/REST/Neo4p.pm
@@ -22,7 +22,7 @@ our @HANDLES;
 our $HANDLE = 0;
 our $AGENT_MODULE = $ENV{REST_NEO4P_AGENT_MODULE} || 'LWP::UserAgent';
 
-my $json = JSON->new->allow_nonref(1);
+my $json = JSON->new->allow_nonref(1)->utf8;
 
 $HANDLES[0]->{_q_endpoint} = 'cypher';
 

--- a/lib/REST/Neo4p.pm
+++ b/lib/REST/Neo4p.pm
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::VERSION = '0.3020';
+  $REST::Neo4p::VERSION = '0.3021';
 }
 
 our $CREATE_AUTO_ACCESSORS = 0;

--- a/lib/REST/Neo4p/Agent.pm
+++ b/lib/REST/Neo4p/Agent.pm
@@ -11,7 +11,7 @@ use warnings;
 our @ISA;
 our $VERSION;
 BEGIN {
-  $REST::Neo4p::Agent::VERSION = '0.3020';
+  $REST::Neo4p::Agent::VERSION = '0.3021';
 }
 
 our $AUTOLOAD;

--- a/lib/REST/Neo4p/Agent/HTTP/Thin.pm
+++ b/lib/REST/Neo4p/Agent/HTTP/Thin.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::Agent::HTTP::Thin::VERSION = 0.3020;
+  $REST::Neo4p::Agent::HTTP::Thin::VERSION = '0.3021';
 }
 
 my $unsafe = "^A-Za-z0-9\-\._~:+?%&=";

--- a/lib/REST/Neo4p/Agent/LWP/UserAgent.pm
+++ b/lib/REST/Neo4p/Agent/LWP/UserAgent.pm
@@ -6,7 +6,7 @@ use LWP::ConnCache;
 use strict;
 use warnings;
 BEGIN {
-  $REST::Neo4p::Agent::LWP::UserAgent::VERSION = "0.3020";
+  $REST::Neo4p::Agent::LWP::UserAgent::VERSION = '0.3021';
 }
 sub new {
   my ($class,@args) = @_;

--- a/lib/REST/Neo4p/Agent/Mojo/UserAgent.pm
+++ b/lib/REST/Neo4p/Agent/Mojo/UserAgent.pm
@@ -10,7 +10,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::Agent::Mojo::UserAgent::VERSION = 0.3020;
+  $REST::Neo4p::Agent::Mojo::UserAgent::VERSION = '0.3021';
 }
 
 our @default_headers;

--- a/lib/REST/Neo4p/Batch.pm
+++ b/lib/REST/Neo4p/Batch.pm
@@ -30,7 +30,7 @@ sub batch (&@) {
   $agent->batch_mode(1);
   $coderef->();
   my $tmpfh = $agent->execute_batch_chunk;
-  my $jsonr = JSON::XS->new();
+  my $jsonr = JSON::XS->new->utf8;
   my $buf;
   $tmpfh->read($buf, $BUFSIZE);
   $jsonr->incr_parse($buf);

--- a/lib/REST/Neo4p/Batch.pm
+++ b/lib/REST/Neo4p/Batch.pm
@@ -13,7 +13,7 @@ use warnings;
 no warnings qw(once);
 
 BEGIN {
-  $REST::Neo4p::Batch::VERSION = '0.3020';
+  $REST::Neo4p::Batch::VERSION = '0.3021';
 }
 
 our @EXPORT = qw(batch);

--- a/lib/REST/Neo4p/Constrain.pm
+++ b/lib/REST/Neo4p/Constrain.pm
@@ -12,7 +12,7 @@ no warnings qw(once redefine);
 
 
 BEGIN {
-  $REST::Neo4p::Constrain::VERSION = '0.3020';
+  $REST::Neo4p::Constrain::VERSION = '0.3021';
 }
 our @EXPORT = qw(create_constraint drop_constraint constrain relax);
 our @VALIDATE = qw(validate_properties validate_relationship validate_relationship_type);

--- a/lib/REST/Neo4p/Constraint.pm
+++ b/lib/REST/Neo4p/Constraint.pm
@@ -31,7 +31,7 @@ my $regex_to_json = sub {
 };
 
 BEGIN {
-  $REST::Neo4p::Constraint::VERSION = '0.3020';
+  $REST::Neo4p::Constraint::VERSION = '0.3021';
 }
 
 # valid constraint types

--- a/lib/REST/Neo4p/Constraint.pm
+++ b/lib/REST/Neo4p/Constraint.pm
@@ -19,7 +19,7 @@ our %EXPORT_TAGS = (
   all => [@EXPORT,@EXPORT_OK]
 );
 
-our $jobj = JSON->new();
+our $jobj = JSON->new->utf8;
 $jobj->allow_blessed(1);
 $jobj->convert_blessed(1);
 my $regex_to_json = sub {

--- a/lib/REST/Neo4p/Constraint/Property.pm
+++ b/lib/REST/Neo4p/Constraint/Property.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::Constraint::Property::VERSION = '0.3020';
+  $REST::Neo4p::Constraint::Property::VERSION = '0.3021';
 }
 
 sub new_from_constraint_hash {
@@ -189,7 +189,7 @@ use base 'REST::Neo4p::Constraint::Property';
 use strict;
 use warnings;
 BEGIN {
-  $REST::Neo4p::Constraint::NodeProperty::VERSION='0.3020';
+  $REST::Neo4p::Constraint::NodeProperty::VERSION='0.3021';
 }
 
 sub new {
@@ -216,7 +216,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::Constraint::RelationshipProperty::VERSION='0.3020';
+  $REST::Neo4p::Constraint::RelationshipProperty::VERSION='0.3021';
 }
 # relationship_type is added as a pseudoproperty
 

--- a/lib/REST/Neo4p/Constraint/Relationship.pm
+++ b/lib/REST/Neo4p/Constraint/Relationship.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::Constraint::Relationship::VERSION = '0.3020';
+  $REST::Neo4p::Constraint::Relationship::VERSION = '0.3021';
 }
 
 sub new {

--- a/lib/REST/Neo4p/Constraint/RelationshipType.pm
+++ b/lib/REST/Neo4p/Constraint/RelationshipType.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::Constraint::RelationshipType::VERSION = '0.3020';
+  $REST::Neo4p::Constraint::RelationshipType::VERSION = '0.3021';
 }
 
 sub new {

--- a/lib/REST/Neo4p/Entity.pm
+++ b/lib/REST/Neo4p/Entity.pm
@@ -10,7 +10,7 @@ use warnings;
 
 # base class for nodes, relationships, indexes...
 BEGIN {
-  $REST::Neo4p::Entity::VERSION = '0.3020';
+  $REST::Neo4p::Entity::VERSION = '0.3021';
 }
 
 our $ENTITY_TABLE = {};
@@ -435,7 +435,7 @@ use strict;
 use warnings;
 no warnings qw/once/;
 BEGIN {
-  $REST::Neo4p::Simple::VERSION = '0.3020';
+  $REST::Neo4p::Simple::VERSION = '0.3021';
 }
 
 sub new { $_[1] }

--- a/lib/REST/Neo4p/Entity.pm
+++ b/lib/REST/Neo4p/Entity.pm
@@ -291,7 +291,7 @@ sub simple_from_json_response {
   return;
 }
 
-sub id { ${$_[0]} }
+sub id { 0 + ${$_[0]} }
 sub is_batch { shift->_entry->{batch} }
 sub entity_type { shift->_entry->{entity_type} }
 

--- a/lib/REST/Neo4p/Exceptions.pm
+++ b/lib/REST/Neo4p/Exceptions.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::Exceptions::VERSION = '0.3020';
+  $REST::Neo4p::Exceptions::VERSION = '0.3021';
 }
 use Exception::Class (
   'REST::Neo4p::Exception',

--- a/lib/REST/Neo4p/Index.pm
+++ b/lib/REST/Neo4p/Index.pm
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::Index::VERSION = '0.3020';
+  $REST::Neo4p::Index::VERSION = '0.3021';
 }
 
 my $unsafe = "^A-Za-z0-9\-\._\ ~";

--- a/lib/REST/Neo4p/Node.pm
+++ b/lib/REST/Neo4p/Node.pm
@@ -8,7 +8,7 @@ use Carp qw(croak carp);
 use strict;
 use warnings;
 BEGIN {
-  $REST::Neo4p::Node::VERSION = '0.3020';
+  $REST::Neo4p::Node::VERSION = '0.3021';
 }
 
 # creation, deletion and property manipulation are delegated

--- a/lib/REST/Neo4p/Node.pm
+++ b/lib/REST/Neo4p/Node.pm
@@ -210,7 +210,7 @@ sub as_simple {
   my $self = shift;
   my $ret;
   my $props = $self->get_properties;
-  $ret->{_node} = $$self;
+  $ret->{_node} = $$self + 0;
   $ret->{$_} = $props->{$_} for keys %$props;
   return $ret;
 }

--- a/lib/REST/Neo4p/ParseStream.pm
+++ b/lib/REST/Neo4p/ParseStream.pm
@@ -7,7 +7,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::ParseStream::VERSION = '0.3020';
+  $REST::Neo4p::ParseStream::VERSION = '0.3021';
 }
 
 our @EXPORT = qw/j_parse/;# j_parse_object j_parse_array /;

--- a/lib/REST/Neo4p/Path.pm
+++ b/lib/REST/Neo4p/Path.pm
@@ -5,7 +5,7 @@ use Carp qw(croak carp);
 use strict;
 use warnings;
 BEGIN {
-  $REST::Neo4p::Path::VERSION = '0.3020';
+  $REST::Neo4p::Path::VERSION = '0.3021';
 }
 
 sub new {

--- a/lib/REST/Neo4p/Query.pm
+++ b/lib/REST/Neo4p/Query.pm
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 no warnings qw(once);
 BEGIN {
-  $REST::Neo4p::Query::VERSION = '0.3020';
+  $REST::Neo4p::Query::VERSION = '0.3021';
 }
 
 our $BUFSIZE = 50000;

--- a/lib/REST/Neo4p/Query.pm
+++ b/lib/REST/Neo4p/Query.pm
@@ -116,7 +116,7 @@ sub execute {
   elsif ( $e = Exception::Class->caught) {
     (ref $e && $e->can("rethrow")) ? $e->rethrow : die $e;
   }
-  my $jsonr = JSON::XS->new;
+  my $jsonr = JSON::XS->new->utf8;
   my ($buf,$res,$str,$rowstr,$obj);
   my $row_count;
   use experimental 'smartmatch';

--- a/lib/REST/Neo4p/Relationship.pm
+++ b/lib/REST/Neo4p/Relationship.pm
@@ -6,7 +6,7 @@ use Carp qw(croak carp);
 use strict;
 use warnings;
 BEGIN {
-  $REST::Neo4p::Relationship::VERSION = '0.3020';
+  $REST::Neo4p::Relationship::VERSION = '0.3021';
 }
 
 sub new {

--- a/lib/REST/Neo4p/Relationship.pm
+++ b/lib/REST/Neo4p/Relationship.pm
@@ -37,7 +37,7 @@ sub as_simple {
   my $self = shift;
   my $ret;
   my $props = $self->get_properties;
-  $ret->{_relationship} = $$self;
+  $ret->{_relationship} = $$self + 0;
   $ret->{_type} = $self->type;
   $ret->{_start} = ${$self->start_node};
   $ret->{_end} = ${$self->end_node};

--- a/lib/REST/Neo4p/Schema.pm
+++ b/lib/REST/Neo4p/Schema.pm
@@ -7,7 +7,7 @@ use strict;
 use warnings;
 
 BEGIN {
-  $REST::Neo4p::Schema::VERSION = '0.3020';
+  $REST::Neo4p::Schema::VERSION = '0.3021';
 }
 
 #require 'REST::Neo4p';

--- a/t/005_db.t
+++ b/t/005_db.t
@@ -1,6 +1,6 @@
 #-*-perl-*-
 #$Id$
-use Test::More tests => 32;
+use Test::More tests => 33;
 use Test::Exception;
 use Module::Build;
 use lib '../lib';
@@ -20,7 +20,7 @@ eval {
     $pass = $build->notes('pass');
 };
 my $TEST_SERVER = $build ? $build->notes('test_server') : 'http://127.0.0.1:7474';
-my $num_live_tests = 31;
+my $num_live_tests = 32;
 
 use_ok('REST::Neo4p');
 
@@ -78,6 +78,7 @@ SKIP : {
   lives_ok { REST::Neo4p->agent->delete_node($$N) } 'delete node';
 #  ok $REST::Neo4p::AGENT->delete_relationship($$R);
   lives_ok { REST::Neo4p->agent->delete_node_index($$I) } 'delete node index';
+  lives_ok { $n2->remove } 'delete node 2';
 }
 
 END {

--- a/t/id_roundtrip.t
+++ b/t/id_roundtrip.t
@@ -1,0 +1,106 @@
+#-*-perl-*-
+use Test::More tests => 35;
+use Test::Exception;
+use Module::Build;
+use lib '../lib';
+use lib 't/lib';
+use Neo4p::Connect;
+use strict;
+use warnings;
+my @cleanup;
+use_ok('REST::Neo4p');
+
+my $build;
+my ($user,$pass);
+
+eval {
+  $build = Module::Build->current;
+  $user = $build->notes('user');
+  $pass = $build->notes('pass');
+};
+
+my $TEST_SERVER = $build ? $build->notes('test_server') : 'http://127.0.0.1:7474';
+
+my $not_connected = connect($TEST_SERVER,$user,$pass);
+diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
+
+
+SKIP : {
+  skip 'no local connection to neo4j', 34 if $not_connected;
+
+  my $n1 = REST::Neo4p::Node->new();
+  ok $n1, 'new node' and push @cleanup, $n1;
+  my $q = REST::Neo4p::Query->new("MATCH (n) WHERE id(n) = {id} RETURN n");
+  $q->{RaiseError} = 1;
+  my $row;
+
+  # Make sure node IDs provided by REST::Neo4p will work with Cypher queries
+  # as-is. Note that upon parsing the response from the Neo4j server,
+  # REST::Neo4p::Entity will return any blessed objects from its internal
+  # entity table rather than the server's JSON response if possible, thus
+  # objects can be compared for identity.
+  # 
+  # Example code:
+  # 
+  #  my $q = REST::Neo4p::Query->new("MATCH (n) WHERE id(n) = {id} RETURN n");
+  #  my $id = REST::Neo4p::Node->new()->id();
+  #  $q->execute( id => $id );
+  #  $q->fetch;
+
+  eval {
+    ok $q->execute( id => $n1->id() ), 'execute node query with ->id()';
+  };
+  is $@, '', 'no error raised';
+  is $q->err, undef, 'no HTTP error code';
+  is $q->errstr, undef, 'no Neo4j error message';
+  lives_ok { $row = $q->fetch } 'fetch';
+  isa_ok $row && $row->[0], 'REST::Neo4p::Node', 'got a node';
+  ok $row && $row->[0] == $n1, 'got same node';
+
+  eval {
+    ok $q->execute( id => $n1->as_simple()->{_node} ), 'execute node query with ->as_simple()';
+  };
+  is $@, '', 'no error raised';
+  is $q->err, undef, 'no HTTP error code';
+  is $q->errstr, undef, 'no Neo4j error message';
+  lives_ok { $row = $q->fetch } 'fetch';
+  isa_ok $row && $row->[0], 'REST::Neo4p::Node', 'got a node';
+  ok $row && $row->[0] == $n1, 'got same node';
+
+
+  # Same for relationships:
+
+  my $n2 = REST::Neo4p::Node->new();
+  ok $n2, '2nd node' and push @cleanup, $n2;
+  my $r = REST::Neo4p::Relationship->new( $n1 => $n2, 'TEST' );
+  ok $r, 'new rel' and push @cleanup, $r;
+  $q = REST::Neo4p::Query->new("MATCH ()-[r]->() WHERE id(r) = {id} RETURN r");
+  $q->{RaiseError} = 1;
+
+  eval {
+    ok $q->execute( id => $r->id() ), 'execute rel query with ->id()';
+  };
+  is $@, '', 'no error raised';
+  is $q->err, undef, 'no HTTP error code';
+  is $q->errstr, undef, 'no Neo4j error message';
+  lives_ok { $row = $q->fetch } 'fetch';
+  isa_ok $row && $row->[0], 'REST::Neo4p::Relationship', 'got a rel';
+  ok $row && $row->[0] == $r, 'got same rel';
+
+  eval {
+    ok $q->execute( id => $r->as_simple()->{_relationship} ), 'execute rel query with ->as_simple()';
+  };
+  is $@, '', 'no error raised';
+  is $q->err, undef, 'no HTTP error code';
+  is $q->errstr, undef, 'no Neo4j error message';
+  lives_ok { $row = $q->fetch } 'fetch';
+  isa_ok $row && $row->[0], 'REST::Neo4p::Relationship', 'got a rel';
+  ok $row && $row->[0] == $r, 'got same rel';
+
+}
+
+CLEANUP : {
+  ok $_->remove, 'entity removed' for reverse grep {ref $_ && $_->can('remove')} @cleanup;
+}
+
+done_testing;

--- a/t/json_utf8.t
+++ b/t/json_utf8.t
@@ -1,0 +1,115 @@
+#-*-perl-*-
+use Test::More tests => 38;
+use Module::Build;
+use lib '../lib';
+use lib 't/lib';
+use Neo4p::Connect;
+use strict;
+use warnings;
+my @cleanup;
+use_ok('REST::Neo4p');
+
+use 5.012;
+use utf8;
+use Data::Dumper;
+
+my $build;
+my ($user,$pass);
+
+eval {
+  $build = Module::Build->current;
+  $user = $build->notes('user');
+  $pass = $build->notes('pass');
+};
+
+my $TEST_SERVER = $build ? $build->notes('test_server') : 'http://127.0.0.1:7474';
+
+my $not_connected = connect($TEST_SERVER,$user,$pass);
+diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
+
+
+sub to_hex ($) {
+  join ' ', map { sprintf "%02x", ord $_ } split m//, shift;
+}
+
+SKIP : {
+  skip 'no local connection to neo4j', 37 if $not_connected;
+
+  my %props = (
+    singlebyte => "\N{U+0025}",  # '%' PERCENT SIGN = 0x25
+    supplement => "\N{U+00E4}",  # 'ä' LATIN SMALL LETTER A WITH DIAERESIS = 0xc3a4
+    extension  => "\N{U+0100}",  # 'Ā' LATIN CAPITAL LETTER A WITH MACRON = 0xc480
+    threebytes => "\N{U+D55C}",  # '한' HANGUL SYLLABLE HAN = 0xed959c
+    smp        => "\N{U+1F600}",  # '😀' GRINNING FACE = 0xf09f9880
+    decomposed => "o\N{U+0302}",  # 'ô' LATIN SMALL LETTER O + COMBINING CIRCUMFLEX ACCENT = 0x6fcc82
+    mixed      => "%äĀ한😀ô",  # 0x25c3a4c480ed959cf09f98806fcc82
+  );
+  my @keys = sort keys %props;
+  my ($row, $simple);
+
+  my $n1 = REST::Neo4p::Node->new( \%props );
+  ok $n1, 'create node' and push @cleanup, $n1;
+  my $id_param = { id => 0 + $n1->id };
+
+  foreach my $key (@keys) {
+    is to_hex $n1->get_property($key), to_hex $props{$key}, "via node->get_property: $key";
+  }
+  # worked as expected (fetches directly from server via $agent->get_data)
+  # ->get_properties worked as well
+  # ->as_simple worked as well (probably via the entity cache)
+
+  my $q2 = REST::Neo4p::Query->new("MATCH (n) WHERE id(n) = {id} RETURN n", $id_param);
+  $q2->{ResponseAsObjects} = 0;
+  $q2->execute;
+  eval { $row = $q2->fetch };
+  ok $row, 'fetch node simple';
+  $simple = $row->[0];
+  foreach my $key (@keys) {
+    is to_hex $simple->{$key}, to_hex $props{$key}, "via simple: $key";
+  }
+  # Node::simple_from_json_response
+  $q2->finish;
+
+  my $q3 = REST::Neo4p::Query->new("MATCH (n) WHERE id(n) = {id} RETURN n." . (join ", n.", @keys), $id_param);
+  $q3->execute;
+  eval { $row = $q3->fetch };
+  ok $row, 'fetch node properties';
+  for (my $i = 0; $i < @keys; $i++) {
+    is to_hex $row->[$i], to_hex $props{$keys[$i]}, "via properties: $keys[$i]";
+  }
+  # Query::_process_row
+  $q3->finish;
+
+  my $n2 = REST::Neo4p::Node->new();
+  ok $n2, 'create node' and push @cleanup, $n2;
+  my $r1 = REST::Neo4p::Relationship->new( $n1 => $n2, 'TEST', \%props );
+  ok $r1, 'create rel' and push @cleanup, $r1;
+  $id_param = { id => 0 + $r1->id };
+  
+  my $q5 = REST::Neo4p::Query->new("MATCH ()-[r]-() WHERE id(r) = {id} RETURN r." . (join ", r.", @keys), $id_param);
+  $q5->execute;
+  eval { $row = $q5->fetch };
+  ok $row, 'fetch rel properties';
+  for (my $i = 0; $i < @keys; $i++) {
+    is to_hex $row->[$i], to_hex $props{$keys[$i]}, "via properties: $keys[$i]";
+  }
+  # Relationship::simple_from_json_response
+  $q5->finish;
+
+  1;
+}
+
+TODO : {
+  # same issue (no ->utf8 on json parser constructor) existed also in:
+  # Neo4p::Batch
+  # Neo4p::get_nodes_by_label
+  # Neo4p::Constraint
+  # (not tested here)
+  1;
+}
+
+CLEANUP : {
+  ok $_->remove, 'entity removed' for reverse grep {ref $_ && $_->can('remove')} @cleanup;
+}
+
+done_testing;


### PR DESCRIPTION
Hi Mark,

during my use of REST::Neo4p, I encountered a number of issues, most significantly insufficient performance in certain applications. I traced that down to network latency due to the large number of REST requests for my Perl code, which traversed a path through a big graph from node to node using the object methods for nodes and relationships provided by REST::Neo4p.

My attempts to solve this by letting the database do that work instead failed because REST::Neo4p uses the deprecated cypher REST endpoint, which only describes paths as a list of entity IDs, requiring REST::Neo4p to make additional roundtrips to get the data I need. Using the transactional endpoint might have solved this, but unfortunately I couldn’t get transactions to work in REST::Neo4p. (This was back when Neo4j 2.2 was current – haven’t tried again since.)

Additionally, REST::Neo4p was unable to understand the Neo4j replies for some of my Cypher queries (see issue #18).

I ended up starting to write my own driver for Neo4j using the transactional REST endpoint, [Neo4j::Driver](https://github.com/johannessen/neo4j-driver-perl) (unfinished, not yet on CPAN). While it does offer a workaround for the issues described above, sadly this way I lose out on the nice object bindings that REST::Neo4p provides.

Anyway, a few other issues I discovered with REST::Neo4p turned out to be easy to solve. I figure it’s only fair to contribute back what little I can. See the individual commits for more info.

Thanks for REST::Neo4p, which made getting started with Neo4j really easy!

Cheers,
Arne