### PR TITLE
Fix compatibility with Neo4j server and Neo4j::Driver

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -78,7 +78,7 @@ my $build =  $class->new
 	'experimental' => 0,
 	'MIME::Base64' => 0,
 	perl => 5.010001,
-	'Neo4j::Driver' => '0.19',
+	'Neo4j::Driver' => '0.21',  # Neo4j::Types
        },
       recommends => {
 	'Mojo::UserAgent' => 0,

--- a/Build.PL
+++ b/Build.PL
@@ -96,6 +96,7 @@ my $build =  $class->new
 	'Mock::Quick' => 0,
 	'List::MoreUtils' => 0,
 	'Mojo::Exception' => 0,
+	'Neo4j::Driver' => '0.26',  # cypher_params v2
 	experimental => 0,
 	'IPC::Run' => 0,
 	'IO::Pty' => 0,
@@ -105,7 +106,6 @@ my $build =  $class->new
 	 'Test::Pod' => 1.0,
 	 'Mojo::UserAgent' => 0,
 	 'HTTP::Thin' => 0,
-	 'Neo4j::Driver' => '0.19',
 	},
       meta_merge => {
 	resources => {

--- a/Build.PL
+++ b/Build.PL
@@ -78,7 +78,7 @@ my $build =  $class->new
 	'experimental' => 0,
 	'MIME::Base64' => 0,
 	perl => 5.010001,
-	'Neo4j::Driver' => '0.21',  # Neo4j::Types
+	'Neo4j::Driver' => '0.26',  # ServerInfo->agent
        },
       recommends => {
 	'Mojo::UserAgent' => 0,

--- a/lib/REST/Neo4p.pm
+++ b/lib/REST/Neo4p.pm
@@ -7,7 +7,7 @@ use URI;
 use URI::Escape;
 use HTTP::Tiny;
 use JSON::ize;
-use Neo4j::Driver 0.1801;
+use Neo4j::Driver 0.26;
 use REST::Neo4p::Agent;
 use REST::Neo4p::Node;
 use REST::Neo4p::Index;
@@ -164,7 +164,7 @@ sub get_neo4j_version {
   my ($url, $user, $pass) = @_;
   my $driver = Neo4j::Driver->new($url);
   $driver->basic_auth($user, $pass) if $user || $pass;
-  my $version = $driver->session->server->version;
+  my $version = $driver->session->server->agent;
   my ($major, $minor, $patch, $milestone) = 
     $version =~ /^Neo4j\/(?:([0-9]+)\.)(?:([0-9]+)\.)?([0-9]+)?(?:-M([0-9]+))?/;
   return wantarray ? ($major, $minor, $patch, $milestone) : $version;

--- a/lib/REST/Neo4p/Agent/Neo4j/Driver.pm
+++ b/lib/REST/Neo4p/Agent/Neo4j/Driver.pm
@@ -2,7 +2,7 @@ package REST::Neo4p::Agent::Neo4j::Driver;
 use v5.10;
 use lib '../../../../../lib'; # testing
 use base qw/REST::Neo4p::Agent/;
-use Neo4j::Driver 0.1803;
+use Neo4j::Driver 0.26;
 use JSON::ize;
 use REST::Neo4p::Agent::Neo4j::DriverActions;
 use REST::Neo4p::Exceptions;
@@ -176,7 +176,7 @@ sub connect {
   for (my $i = $REST::Neo4p::Agent::RQ_RETRIES; $i>0; $i--) {
     my $f;
     try {
-      my $version = $drv->session->server->version;
+      my $version = $drv->session->server->agent;
       $version =~ s|^\S+/||;  # server version strings look like "Neo4j/3.2.1"
       $self->{_actions}{neo4j_version} = $version or
         die "Can't find neo4j_version from server";

--- a/lib/REST/Neo4p/Agent/Neo4j/Driver.pm
+++ b/lib/REST/Neo4p/Agent/Neo4j/Driver.pm
@@ -229,6 +229,7 @@ sub run_in_session {
   $params = {} unless defined $params;
   try {
     $self->{_last_result} = $self->session->run($qry, $params);
+	$self->{_last_result}->has_next;  # Make sure the query has executed and any errors have been thrown
   } catch {
     $self->{_last_errors} = $_;
   };
@@ -243,6 +244,7 @@ sub run_in_transaction {
   $params = {} unless defined $params;
   try {
     $self->{_last_result} = $tx->run($qry, $params);
+	$self->{_last_result}->has_next;  # Make sure the query has executed and any errors have been thrown
   } catch {
     $self->{_last_errors} = $_;
   };

--- a/lib/REST/Neo4p/Agent/Neo4j/DriverActions.pm
+++ b/lib/REST/Neo4p/Agent/Neo4j/DriverActions.pm
@@ -858,7 +858,8 @@ sub post_index {
       for ($ent) {
 	/^node$/ && do {
 	  $result = $self->run_in_session("create (n) $set_clause return n");
-	  $content->{id} = 0+$result->fetch->get(0)->id;
+	  my $node = $result->fetch->get(0);
+	  $content->{id} = do { no warnings 'deprecated'; 0 + $node->id };
 	  if ($self->is_version_4) {
 	    my $hkey = encode_base64url($content->{key},'');
 	    my $xi_prop = "_xi_$hkey";
@@ -885,7 +886,8 @@ sub post_index {
 	  $content->{start} = 0+$start;
 	  $content->{end} = 0+$end;
 	  $result = $self->run_in_session("match (s), (t) where id(s)=\$start and id(t)=\$end create (s)-[n:$type]->(t) $set_clause return n", $content);
-	  $content->{id} = 0+$result->fetch->get(0)->id;
+	  my $relationship = $result->fetch->get(0);
+	  $content->{id} = do { no warnings 'deprecated'; 0 + $relationship->id };
 	  if ($self->is_version_4) {
 	    my $hkey = encode_base64url($content->{key},'');
 	    my $xi_prop = "_xi_$hkey";

--- a/lib/REST/Neo4p/Agent/Neo4j/DriverActions.pm
+++ b/lib/REST/Neo4p/Agent/Neo4j/DriverActions.pm
@@ -616,6 +616,8 @@ sub get_index {
     $result = $self->is_version_4 ?
       $self->run_in_session('call db.indexes() yield name, type, entityType where type = "FULLTEXT" and entityType = $ent return entityType, name, type',{ent => uc $ent}) :
       $self->run_in_session('call db.index.explicit.list()');
+      # Neo4j 4.3+ syntax:
+      # $self->run_in_session('show indexes yield name, type, entityType where type = "FULLTEXT" and entityType = $ent return entityType, name, type',{ent => uc $ent}) :
   }
   else {
     # find things
@@ -697,6 +699,8 @@ sub delete_index {
       }
       else {
 	$result = $tx->run("match ()-[r]->() where exists(r.__${idx}__keys) return distinct r.__${idx}__keys");
+	# Neo4j 4.3+ syntax:
+	# $result = $tx->run("match ()-[r]->() where r.`__${idx}__keys` is not null return distinct r.`__${idx}__keys`");
       }
       my (%k,%remove);
       for my $k ($result->list()) {
@@ -712,9 +716,13 @@ sub delete_index {
       else { #relationship
 	$tx->run("match ()-[r]->() where exists(r.__${idx}__keys) set r += \$rm remove r.__${idx}__keys",
 		 { rm => \%remove });
+	# Neo4j 4.3+ syntax:
+	# $tx->run("match ()-[r]->() where r.`__${idx}__keys` is not null set r += \$rm remove r.`__${idx}__keys`",
       }
       $tx->commit;
       $result = $self->run_in_session('call db.index.fulltext.drop($idx)', {idx => $idx});
+      # Neo4j 4.3+ syntax:
+      # $result = $self->run_in_session(sprintf 'DROP INDEX `%s`', $idx);
     }
     else {
       $result = $self->run_in_session('call db.index.explicit.drop($idx)',{idx => $idx});
@@ -785,6 +793,14 @@ sub post_index {
 	token => $content->{type} // "__$$content{name}__index",
 	prop => "__$$content{name}__keys"
        });
+      # Neo4j 4.3+ syntax:
+      # my $token = $content->{type} // "__$$content{name}__index";
+      # my $ent_pattern = ($ent eq 'node') ? "(x:`$token`)" : "()-[x:`$token`]-()";
+      # $result = $self->run_in_session(
+      #   sprintf "CREATE FULLTEXT INDEX `%s` FOR %s ON EACH [x.`%s`] OPTIONS {indexConfig: {`fulltext.analyzer`:'whitespace'}}",
+      #   $content->{name}, $ent_pattern, "__$$content{name}__keys"
+      # )->consume;
+      # $result = $self->run_in_session("RETURN 1");
     }
     else {
       my $for = ($ent eq 'node') ? 'forNodes' : 'forRelationships';
@@ -947,6 +963,8 @@ sub get_schema_constraint {
   my @constraints;
   my $result;
   $result = $self->run_in_session('call db.constraints()');
+  # Neo4j 4.3+ syntax:
+  # $result = $self->run_in_session($self->is_version_4 ? 'SHOW CONSTRAINTS' : 'call db.constraints()');
   if ($result) {
     while (my $rec = $result->fetch) {
       my ($node_label,$reln_type,$x_prop, $u_prop) =
@@ -1062,6 +1080,8 @@ sub get_schema_index {
   my $q;
   if ($maj > 3) {
     $q = 'call db.indexes() yield labelsOrTypes as labels, properties where $lbl in labels return { label:$lbl, property_keys:properties }';
+    # Neo4j 4.3+ syntax:
+    # $q = 'show indexes yield labelsOrTypes as labels, properties where $lbl in labels return { label:$lbl, property_keys:properties }';
   }
   elsif ($maj==3 && $min>=5) { # patch
     $q = 'call db.indexes() yield tokenNames as labels, properties where $lbl in labels return { label:$lbl, property_keys:properties }';

--- a/lib/REST/Neo4p/Agent/Neo4j/ResultProcessor.pm
+++ b/lib/REST/Neo4p/Agent/Neo4j/ResultProcessor.pm
@@ -2,6 +2,7 @@ package
   REST::Neo4p::Agent::Neo4j::Driver;
 
 use REST::Neo4p::Exceptions;
+use strict;
 
 our %result_processors;
 
@@ -18,8 +19,9 @@ $result_processors{get_node} = sub {
     my @r = $_->list;
     REST::Neo4p::NotFoundException->throw unless @r;
     $r = $r[0]->get(0);
-    return { metadata => { id => $r->id, labels => [$r->labels] },
-	     self => 'node/'.$r->id,
+    my $id = do { no warnings 'deprecated'; $r->id };
+    return { metadata => { id => $id, labels => [$r->labels] },
+	     self => 'node/'.$id,
 	     data => $r->properties };
   }
   else {
@@ -33,12 +35,13 @@ $result_processors{get_node} = sub {
       my $ret = [];
       while (my $rec = $_->fetch) {
 	$r = $rec->get(0);
+	my $id = do { no warnings 'deprecated'; $r->id };
 	push @$ret, {
-	  metadata => { id => $r->id, type => $r->type },
-	  self => 'relationship/'.$r->id,
+	  metadata => { id => $id, type => $r->type },
+	  self => 'relationship/'.$id,
 	  data => $r->properties,
-	  start => 'node/'.$r->start_id,
-	  end => 'node/'.$r->end_id,
+	  start => 'node/' . do { no warnings 'deprecated'; $r->start_id },
+	  end => 'node/' . do { no warnings 'deprecated'; $r->end_id },
 	  type => $r->type
 	 }
       }
@@ -58,9 +61,10 @@ $result_processors{post_node} = sub {
     my @r = $_->list;
     REST::Neo4p::NotFoundException->throw unless @r;
     $r = $r[0]->get(0);
+    my $id = do { no warnings 'deprecated'; $r->id };
     return {
-      metadata => { id => $r->id, labels => [] },
-      self => 'node/'.$r->id,
+      metadata => { id => $id, labels => [] },
+      self => 'node/'.$id,
       data => {}
      };
   }
@@ -73,12 +77,13 @@ $result_processors{post_node} = sub {
       my @r = $_->list;
       REST::Neo4p::NotFoundException->throw unless @r;
       $r = $r[0]->get(0);
+      my $id = do { no warnings 'deprecated'; $r->id };
       return {
-	  metadata => { id => $r-id, type => $r->type },
-	  self => 'relationship/'.$r->id,
+	  metadata => { id => $id, type => $r->type },
+	  self => 'relationship/'.$id,
 	  data => $r->properties,
-	  start => 'node/'.$r->start_id,
-	  end => 'node/'.$r->end_id,
+	  start => 'node/' . do { no warnings 'deprecated'; $r->start_id },
+	  end => 'node/' . do { no warnings 'deprecated'; $r->end_id },
 	  type => $r->type
 	 };
     };
@@ -95,12 +100,13 @@ $result_processors{get_relationship} = sub {
       my @r = $_->list;
       REST::Neo4p::NotFoundException->throw() unless @r;
       my $r = $r[0]->get(0);
+      my $id = do { no warnings 'deprecated'; $r->id };
       return {
-	  metadata => { id => $r->id, type => $r->type },
-	  self => 'relationship/'.$r->id,
+	  metadata => { id => $id, type => $r->type },
+	  self => 'relationship/'.$id,
 	  data => $r->properties,
-	  start => 'node/'.$r->start_id,
-	  end => 'node/'.$r->end_id,
+	  start => 'node/' . do { no warnings 'deprecated'; $r->start_id },
+	  end => 'node/' . do { no warnings 'deprecated'; $r->end_id },
 	  type => $r->type
 	 };
     };
@@ -109,7 +115,7 @@ $result_processors{get_relationship} = sub {
     ($other[0] eq 'properties') && do {
       my @r = $_->list;
       REST::Neo4p::NotFoundException->throw unless @r;
-      $r = $r[0]->get(0);
+      my $r = $r[0]->get(0);
       return $r;
     };
     return;
@@ -132,8 +138,9 @@ $result_processors{get_label} = sub {
   my $ret = [];
   while (my $rec = $_->fetch) {
     my $r = $rec->get(0);
-    push @$ret, { metadata => { id => $r->id, labels => [$r->labels] },
-		  self => 'node/'.$r->id,
+    my $id = do { no warnings 'deprecated'; $r->id };
+    push @$ret, { metadata => { id => $id, labels => [$r->labels] },
+		  self => 'node/'.$id,
 		  data => $r->properties };
   }
   return $ret;
@@ -159,8 +166,9 @@ $result_processors{get_index} = sub {
     while (my $rec = $_->fetch) {
       my $r = $rec->get(0);
       my @labels = (ref($r) =~ /Node/ ? (labels => [$r->labels]) : ());
-      push @$ret, { metadata => { id => $r->id, @labels },
-		    self => 'node/'.$r->id,
+      my $id = do { no warnings 'deprecated'; $r->id };
+      push @$ret, { metadata => { id => $id, @labels },
+		    self => 'node/'.$id,
 		    data => $r->properties };
     }
     REST::Neo4p::NotFoundException->throw unless @$ret;
@@ -181,14 +189,14 @@ $result_processors{post_index} = sub {
   else {
     my $n = $_->fetch->get(0);
     return unless ref $n;
-    my $id = $n->id;
+    my $id = do { no warnings 'deprecated'; $n->id };
     return {
       metadata => { id => $id },
       self => "$ent/$id",
       ($n->properties ? (data => $n->properties) : ()),
-      ($n->can(start_id) ? (
-	start_id => $n->start_id,
-	end_id => $n->end_id,
+      ($n->can('start_id') ? (
+	start_id => do { no warnings 'deprecated'; $n->start_id },
+	end_id => do { no warnings 'deprecated'; $n->end_id },
 	type => $n->type
        ) : ()),
       indexed => "index/$ent/$idx/$$content{key}/$$content{value}/$id"

--- a/lib/REST/Neo4p/Entity.pm
+++ b/lib/REST/Neo4p/Entity.pm
@@ -83,6 +83,7 @@ sub new_from_json_response {
     ($obj) = $self_url =~ /([a-z0-9_]+)\/?$/i;
   }
   else { # Driver
+    no warnings 'deprecated';  # id() in Neo4j 5
     $obj = $decoded_resp->id;
     $self_url = "$entity_type/$obj";
   }
@@ -97,8 +98,8 @@ sub new_from_json_response {
   }
   else { # Driver
     if ($decoded_resp->can('start_id')) {
-      $start_id = $decoded_resp->start_id;
-      $end_id = $decoded_resp->end_id;
+      $start_id = do { no warnings 'deprecated'; $decoded_resp->start_id };
+      $end_id = do { no warnings 'deprecated'; $decoded_resp->end_id };
       $type = $decoded_resp->type;
     }
   }

--- a/lib/REST/Neo4p/Entity.pm
+++ b/lib/REST/Neo4p/Entity.pm
@@ -4,6 +4,7 @@ package REST::Neo4p::Entity;
 use REST::Neo4p::Exceptions;
 use Carp qw(croak carp);
 use JSON;
+use Scalar::Util qw(blessed);
 use URI::Escape;
 use strict;
 use warnings;
@@ -65,7 +66,7 @@ sub new_from_json_response {
   unless (defined $decoded_resp) {
     REST::Neo4p::LocalException->throw("new_from_json_response() called with undef argument\n");
   }
-  my $is_json = !(ref($decoded_resp) =~ /Neo4j::Driver/);
+  my $is_json = ! blessed $decoded_resp;  # blessed via Neo4j::Driver
   unless ($ENTITY_TABLE->{$entity_type}{_actions} || !$is_json) {
     # capture the url suffix patterns for the entity actions:
     for (keys %$decoded_resp) {

--- a/lib/REST/Neo4p/Index.md
+++ b/lib/REST/Neo4p/Index.md
@@ -37,6 +37,8 @@ functionality, the agent based on [Neo4j::Driver](https://metacpan.org/pod/Neo4j
 indexes under the hood to emulate explicit indexes. This agent is used
 automatically with Neo4j version 4.0 servers.
 
+Note that this index emulation currently doesn't work with Neo4j 5.
+
 # METHODS
 
 - new()

--- a/lib/REST/Neo4p/Index.pm
+++ b/lib/REST/Neo4p/Index.pm
@@ -359,6 +359,8 @@ functionality, the agent based on L<Neo4j::Driver> uses fulltext
 indexes under the hood to emulate explicit indexes. This agent is used
 automatically with Neo4j version 4.0 servers.
 
+Note that this index emulation currently doesn't work with S<Neo4j 5.>
+
 =head1 METHODS
 
 =over

--- a/lib/REST/Neo4p/Node.pm
+++ b/lib/REST/Neo4p/Node.pm
@@ -222,8 +222,8 @@ sub simple_from_json_response {
   my $class = shift;
   my ($decoded_resp) = @_;
   my $ret;
-  for (ref $decoded_resp) {
-    /HASH/ && do {
+  for ($decoded_resp) {
+    ref eq 'HASH' && do {
       # node id
       ($ret->{_node}) = $decoded_resp->{self} =~ m{.*/([0-9]+)$};
       # node properties
@@ -235,7 +235,7 @@ sub simple_from_json_response {
       }
       last;
     };
-    /Driver/ && do {
+    $_->isa('Neo4j::Types::Node') && do {  # via Neo4j::Driver
       $ret->{_node} = $decoded_resp->id;
       $ret->{$_} = $decoded_resp->properties->{$_} for keys %{$decoded_resp->properties};
       last;

--- a/lib/REST/Neo4p/Node.pm
+++ b/lib/REST/Neo4p/Node.pm
@@ -236,7 +236,7 @@ sub simple_from_json_response {
       last;
     };
     $_->isa('Neo4j::Types::Node') && do {  # via Neo4j::Driver
-      $ret->{_node} = $decoded_resp->id;
+      $ret->{_node} = do { no warnings 'deprecated'; $decoded_resp->id };
       $ret->{$_} = $decoded_resp->properties->{$_} for keys %{$decoded_resp->properties};
       last;
     };

--- a/lib/REST/Neo4p/Path.pm
+++ b/lib/REST/Neo4p/Path.pm
@@ -69,7 +69,8 @@ sub new_from_driver_obj {
     my $r = shift @relns;
     my ($node, $relationship);
     eval {
-      $node = REST::Neo4p::Node->_entity_by_id($n->id);
+      my $id = do { no warnings 'deprecated'; $n->id };
+      $node = REST::Neo4p::Node->_entity_by_id($id);
     };
     if (my $e = REST::Neo4p::Exception->caught()) {
       # TODO : handle different classes
@@ -80,6 +81,7 @@ sub new_from_driver_obj {
     }
     push @{$obj->{_nodes}}, $node;
     eval {
+      no warnings 'deprecated';  # id() in Neo4j 5
       $relationship =  REST::Neo4p::Relationship->_entity_by_id($r->id) if defined $r;
     };
     if (my $e = REST::Neo4p::Exception->caught()) {

--- a/lib/REST/Neo4p/Path.pm
+++ b/lib/REST/Neo4p/Path.pm
@@ -2,6 +2,7 @@
 package REST::Neo4p::Path;
 use REST::Neo4p::Exceptions;
 use Carp qw(croak carp);
+use Scalar::Util qw(blessed);
 use strict;
 use warnings;
 BEGIN {
@@ -16,7 +17,7 @@ sub new {
 sub new_from_json_response {
   my $class = shift;
   my ($decoded_resp) = @_;
-  return $class->new_from_driver_obj(@_) if (ref($decoded_resp) =~ /Neo4j::Driver/);
+  return $class->new_from_driver_obj(@_) if blessed $decoded_resp;
   REST::Neo4p::LocalException->throw("Arg does not describe a Neo4j path response\n") unless $decoded_resp->{start} && $decoded_resp->{end} && $decoded_resp->{relationships} && $decoded_resp->{nodes};
   my $obj = bless {}, $class;
   $obj->{_length} = $decoded_resp->{length};

--- a/lib/REST/Neo4p/Relationship.pm
+++ b/lib/REST/Neo4p/Relationship.pm
@@ -63,11 +63,11 @@ sub simple_from_json_response {
       last;
     };
     $_->isa('Neo4j::Types::Relationship') && do {  # via Neo4j::Driver
-      $ret->{_relationship} = $decoded_resp->id;
+      $ret->{_relationship} = do { no warnings 'deprecated'; $decoded_resp->id };
       $ret->{_type} = $decoded_resp->type;
       $ret->{$_} = $decoded_resp->properties->{$_} for keys %{$decoded_resp->properties};
-      $ret->{_start} = $decoded_resp->start_id;
-      $ret->{_end} = $decoded_resp->end_id;
+      $ret->{_start} = do { no warnings 'deprecated'; $decoded_resp->start_id };
+      $ret->{_end} = do { no warnings 'deprecated'; $decoded_resp->end_id };
       last;
     };
     do {

--- a/lib/REST/Neo4p/Relationship.pm
+++ b/lib/REST/Neo4p/Relationship.pm
@@ -49,8 +49,8 @@ sub simple_from_json_response {
   my $class = shift;
   my ($decoded_resp) = @_;
   my $ret;
-  for (ref $decoded_resp) {
-    /HASH/ && do {
+  for ($decoded_resp) {
+    ref eq 'HASH' && do {
       # reln id
       ($ret->{_relationship}) = $decoded_resp->{self} =~ m{.*/([0-9]+)$};
       # reln type
@@ -62,7 +62,7 @@ sub simple_from_json_response {
       ($ret->{_end}) = $decoded_resp->{end} =~ m{.*/([0-9]+)$};
       last;
     };
-    /Driver/ && do {
+    $_->isa('Neo4j::Types::Relationship') && do {  # via Neo4j::Driver
       $ret->{_relationship} = $decoded_resp->id;
       $ret->{_type} = $decoded_resp->type;
       $ret->{$_} = $decoded_resp->properties->{$_} for keys %{$decoded_resp->properties};

--- a/t/0041_idx_create_unique.t
+++ b/t/0041_idx_create_unique.t
@@ -1,5 +1,5 @@
 #$Id$
-use Test::More tests => 24;
+use Test::More;
 use Module::Build;
 use lib '../lib';
 use lib qw'lib t/lib';
@@ -17,15 +17,17 @@ eval {
   $pass = $build->notes('pass');
 };
 my $TEST_SERVER = $build ? $build->notes('test_server') : $ENV{REST_NEO4P_TEST_SERVER} // 'http://127.0.0.1:7474';
-my $num_live_tests = 23;
 
-use_ok('REST::Neo4p');
+use REST::Neo4p;
 
 my $not_connected = connect($TEST_SERVER, $user, $pass);
 diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
 
-SKIP : {
-  skip 'no local connection to neo4j', $num_live_tests if $not_connected;
+plan skip_all => neo4j_index_unavailable() if neo4j_index_unavailable();
+plan skip_all => 'no local connection to neo4j' if $not_connected;
+plan tests => 23;
+
+{
   my @cleanup;
   if ( my $i = REST::Neo4p->get_index_by_name('nidx555','node') ) { $i->remove }
   if ( my $i = REST::Neo4p->get_index_by_name('ridx555','relationship') ) { $i->remove }

--- a/t/004_idx.t
+++ b/t/004_idx.t
@@ -14,15 +14,17 @@ eval {
   $pass = $build->notes('pass');
 };
 my $TEST_SERVER = $build ? $build->notes('test_server') : $ENV{REST_NEO4P_TEST_SERVER} // 'http://127.0.0.1:7474';
-my $num_live_tests = 67;
 
-use_ok('REST::Neo4p');
+use REST::Neo4p;
 
 my $not_connected = connect($TEST_SERVER,$user,$pass);
 diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
 
-SKIP : {
-  skip 'no local connection to neo4j', $num_live_tests if $not_connected;
+plan skip_all => neo4j_index_unavailable() if neo4j_index_unavailable();
+plan skip_all => 'no local connection to neo4j' if $not_connected;
+plan tests => 67;
+
+{
   my @node_defs = 
     (
      { name => 'A', type => 'purine' },

--- a/t/005_db.t
+++ b/t/005_db.t
@@ -1,6 +1,6 @@
 #-*-perl-*-
 #$Id$
-use Test::More tests => 33;
+use Test::More;
 use Test::Exception;
 use Module::Build;
 use lib '../lib';
@@ -20,15 +20,17 @@ eval {
     $pass = $build->notes('pass');
 };
 my $TEST_SERVER = $build ? $build->notes('test_server') : $ENV{REST_NEO4P_TEST_SERVER} // 'http://127.0.0.1:7474';
-my $num_live_tests = 32;
 
-use_ok('REST::Neo4p');
+use REST::Neo4p;
 
 my $not_connected = connect($TEST_SERVER,$user,$pass);
 diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
 
-SKIP : {
-  skip 'no local connection to neo4j', $num_live_tests if $not_connected;
+plan skip_all => neo4j_index_unavailable() if neo4j_index_unavailable();
+plan skip_all => 'no local connection to neo4j' if $not_connected;
+plan tests => 32;
+
+{
   ok my $n1 = REST::Neo4p::Node->new(), 'node 1';
 #  push @cleanup, $n1 if $n1;
   ok my $n2 = REST::Neo4p::Node->new(), 'node 2';

--- a/t/006_query.t
+++ b/t/006_query.t
@@ -41,6 +41,7 @@ is_deeply $q->params, { node_id => 1}, 'params accessor';
 
 SKIP : {
   skip 'no local connection to neo4j', $num_live_tests if $not_connected;
+  skip 'MATCH query requires Neo4j 2 or later', $num_live_tests unless REST::Neo4p->_check_version(2,0,0,0);
 
   ok my $n1 = REST::Neo4p::Node->new({name => 'Fred', role => 'husband'}), 'Fred';
   ok my $n2 = REST::Neo4p::Node->new({name => 'Wilma', role => 'wife'}), 'Wilma';

--- a/t/007_accessors.t
+++ b/t/007_accessors.t
@@ -51,6 +51,7 @@ SKIP : {
   lives_and { ok $n3->set_blue(5) } 'blue setter called';
   lives_and { is $n3->blue, 5 } 'blue setter works';
   my $idx;
+  if (neo4j_index_unavailable()) { pass; pass; diag neo4j_index_unavailable(); last SKIP; }
   lives_ok {$idx = REST::Neo4p::Index->new('relationship','heydude', {rtype => 'dude'})} 'index should be created np';
   push @cleanup, $idx if $idx;
 

--- a/t/011_neo4p_synopsis.t
+++ b/t/011_neo4p_synopsis.t
@@ -6,7 +6,7 @@ use Module::Build;
 use lib '../lib';
 use lib 'lib';
 use lib 't/lib';
-use Neo4p::Connect;
+use Neo4p::Connect ':cypher_params_v2';
 use strict;
 use warnings;
 no warnings qw(once);
@@ -49,7 +49,7 @@ plan tests => 13 + 4;
   is $my_reln->end_node->get_property('name'), 'Donkey Hoty', 'got Donkey Hoty';
   push @cleanup, $my_reln if $my_reln;
   ok my $query = REST::Neo4p::Query->new("MATCH p = (n)-[]->()
-                                    WHERE id(n) = \$id
+                                    WHERE id(n) = {id}
                                     RETURN p", {id => $my_node->id});
   ok $query->execute;
   my $path = $query->fetch->[0];

--- a/t/011_neo4p_synopsis.t
+++ b/t/011_neo4p_synopsis.t
@@ -30,6 +30,7 @@ diag "Test server unavailable (".$not_connected->message.") : tests skipped" if 
 
 plan skip_all => neo4j_index_unavailable() if neo4j_index_unavailable();
 plan skip_all => 'no local connection to neo4j' if $not_connected;
+plan skip_all => 'MATCH query requires Neo4j 2 or later' unless REST::Neo4p->_check_version(2,0,0,0);
 plan tests => 13 + 4;
 
 {

--- a/t/011_neo4p_synopsis.t
+++ b/t/011_neo4p_synopsis.t
@@ -1,6 +1,6 @@
 #-*-perl-*-
 #$Id$
-use Test::More qw(no_plan);
+use Test::More 0.88;
 use Test::Exception;
 use Module::Build;
 use lib '../lib';
@@ -11,7 +11,7 @@ use strict;
 use warnings;
 no warnings qw(once);
 my @cleanup;
-use_ok('REST::Neo4p');
+use REST::Neo4p;
 
 my $build;
 my ($user,$pass) = @ENV{qw/REST_NEO4P_TEST_USER REST_NEO4P_TEST_PASS/};
@@ -24,15 +24,15 @@ eval {
 };
 
 my $TEST_SERVER = $build ? $build->notes('test_server') : $ENV{REST_NEO4P_TEST_SERVER} // 'http://127.0.0.1:7474';
-my $num_live_tests = 13;
 
 my $not_connected = connect($TEST_SERVER,$user,$pass);
 diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
 
+plan skip_all => neo4j_index_unavailable() if neo4j_index_unavailable();
+plan skip_all => 'no local connection to neo4j' if $not_connected;
+plan tests => 13 + 4;
 
-SKIP : {
-  skip 'no local connection to neo4j', $num_live_tests if $not_connected;
-
+{
   ok my $i = REST::Neo4p::Index->new('node', 'my_node_index');
   push @cleanup, $i if $i;
   my $f;

--- a/t/030_idx_escape.t
+++ b/t/030_idx_escape.t
@@ -1,7 +1,7 @@
 #-*- perl -*-
 #$Id$
 
-use Test::More qw(no_plan);
+use Test::More 0.88;
 use Module::Build;
 use lib '../lib';
 use lib 'lib';
@@ -21,15 +21,16 @@ eval {
 };
 my $TEST_SERVER = $build ? $build->notes('test_server') : $ENV{REST_NEO4P_TEST_SERVER} // 'http://127.0.0.1:7474';
 
-my $num_live_tests = 1;
-
-use_ok('REST::Neo4p');
+use REST::Neo4p;
 
 my $not_connected = connect($TEST_SERVER,$user,$pass);
 diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
 
-SKIP : {
-  skip 'no local connection to neo4j', $num_live_tests if $not_connected;
+plan skip_all => neo4j_index_unavailable() if neo4j_index_unavailable();
+plan skip_all => 'no local connection to neo4j' if $not_connected;
+plan tests => 4 + 5;
+
+{
   my @node_defs = 
     (
      { name => 'A', type => 'purine' },
@@ -53,3 +54,5 @@ SKIP : {
     ok ($_->remove, 'entity removed') for reverse @cleanup;
   }
   }
+
+done_testing;

--- a/t/041_v2_txns.t
+++ b/t/041_v2_txns.t
@@ -31,6 +31,14 @@ diag "Test server unavailable (".$not_connected->message.") : tests skipped" if 
 SKIP : {
   skip "Neo4j server version >= 2.0.0-M02 required, skipping...", $num_live_tests unless  REST::Neo4p->_check_version(2,0,0,2);
 
+  skip 'Returning entities via tx endpoint needs either Driver agent or Neo4j 3.5+', $num_live_tests
+    unless REST::Neo4p->_check_version(3,5,0,0)
+    || REST::Neo4p->agent->isa('REST::Neo4p::Agent::Neo4j::Driver');
+  # There is a known bug in _process_row/_response_entity in REST::Neo4p::Query
+  # that can prevent correct parsing of metadata for entities returned via the
+  # transaction endpoint. The metadata format varied between Neo4j versions.
+  # REST::Neo4p 0.3012-0.3030 worked correctly on some (not all) Neo4j versions.
+
 my $neo4p = 'REST::Neo4p';
 my ($n, $m);
 SKIP : {

--- a/t/041_v2_txns.t
+++ b/t/041_v2_txns.t
@@ -6,7 +6,7 @@ use lib 'lib';
 use lib 't/lib';
 use REST::Neo4p;
 use Neo4p::Test;
-use Neo4p::Connect;
+use Neo4p::Connect ':cypher_params_v2';
 use strict;
 use warnings;
 no warnings qw(once);
@@ -35,8 +35,6 @@ my $neo4p = 'REST::Neo4p';
 my ($n, $m);
 SKIP : {
   skip 'no local connection to neo4j', $num_live_tests if $not_connected;
-  REST::Neo4p->create_and_set_handle(cypher_filter => 'params');
-  connect($TEST_SERVER, $user, $pass);
   ok my $t = Neo4p::Test->new, 'test graph object';
 
   ok $t->create_sample, 'create sample graph';

--- a/t/050_v2_schema.t
+++ b/t/050_v2_schema.t
@@ -1,5 +1,5 @@
 #$Id#
-use Test::More tests => 29;
+use Test::More;
 use Test::Exception;
 use Module::Build;
 use lib '../lib';
@@ -23,17 +23,17 @@ eval {
     $pass = $build->notes('pass');
 };
 my $TEST_SERVER = $build ? $build->notes('test_server') : $ENV{REST_NEO4P_TEST_SERVER} // 'http://127.0.0.1:7474';
-my $num_live_tests = 29;
 
 my $not_connected = connect($TEST_SERVER,$user,$pass);
 diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
 
-SKIP : {
-  skip 'no local connection to neo4j', $num_live_tests if $not_connected;
-  my $version = REST::Neo4p->neo4j_version;
-  my $VERSION_OK = REST::Neo4p->_check_version(2,0,1);
-  SKIP : {
-    skip "Server version $version < 2.0.1", $num_live_tests unless $VERSION_OK;
+plan skip_all => neo4j_index_unavailable() if neo4j_index_unavailable();
+plan skip_all => 'no local connection to neo4j' if $not_connected;
+plan skip_all => sprintf 'Server version %s < 2.0.1', scalar REST::Neo4p->neo4j_version
+  unless REST::Neo4p->_check_version(2,0,1);
+plan tests => 29;
+
+{
     ok my $schema = REST::Neo4p::Schema->new, 'new Schema object';
     isa_ok $schema, 'REST::Neo4p::Schema';
     is $schema->_handle, REST::Neo4p->handle, 'handle correct';
@@ -78,8 +78,6 @@ SKIP : {
     ok $n2->set_property({name=>"Fred"}), 'constraint lifted, can set label';
     is $n2->get_property('name'), 'Fred', 'property now set';
     1;
-  }
-
 }
 
 END {

--- a/t/099_error.t
+++ b/t/099_error.t
@@ -1,5 +1,5 @@
 #$Id$
-use Test::More qw(no_plan);
+use Test::More 0.88;
 use Test::Exception;
 use Module::Build;
 use lib '../lib';
@@ -21,7 +21,7 @@ eval {
 };
 
 my $TEST_SERVER = $build ? $build->notes('test_server') : $ENV{REST_NEO4P_TEST_SERVER} // 'http://127.0.0.1:7474';
-my $num_live_tests = 1;
+my $num_live_tests = 18;
 
 throws_ok { REST::Neo4p->get_indexes('relationship') } 'REST::Neo4p::CommException', 'not connected ok';
 like $@->message, qr/not connected/i, 'not connected ok (2)';
@@ -57,6 +57,7 @@ SKIP : {
     lives_ok { $q->err } 'LocalException->code works';
     $q->{_error} = REST::Neo4p::TxException->new();
     lives_ok { $q->err } 'TxException->code works';
+    if (neo4j_index_unavailable()) { diag neo4j_index_unavailable(); last SKIP; }
     ok my $i = REST::Neo4p::Index->new('node','zzyxx'), 'create index';
     throws_ok { $i->get_property('foo') } 'REST::Neo4p::NotSuppException', 'not supported ok';
     throws_ok { $i->set_property(foo => 'bar') } 'REST::Neo4p::NotSuppException', 'not supported ok (2)';
@@ -67,3 +68,5 @@ SKIP : {
     ok $n1->remove, 'remove node';
     ok $i->remove, 'remove index';
 }
+
+done_testing;

--- a/t/id_roundtrip.t
+++ b/t/id_roundtrip.t
@@ -4,7 +4,7 @@ use Test::Exception;
 use Module::Build;
 use lib qw|../lib lib|;
 use lib 't/lib';
-use Neo4p::Connect;
+use Neo4p::Connect ':cypher_params_v2';
 use strict;
 use warnings;
 my @cleanup;
@@ -28,7 +28,7 @@ SKIP : {
 
   my $n1 = REST::Neo4p::Node->new();
   ok $n1, 'new node' and push @cleanup, $n1;
-  my $q = REST::Neo4p::Query->new('MATCH (n) WHERE id(n) = $id RETURN n');
+  my $q = REST::Neo4p::Query->new('MATCH (n) WHERE id(n) = {id} RETURN n');
   $q->{RaiseError} = 1;
   my $row;
 
@@ -40,7 +40,7 @@ SKIP : {
   # 
   # Example code:
   # 
-  #  my $q = REST::Neo4p::Query->new('MATCH (n) WHERE id(n) = $id RETURN n');
+  #  my $q = REST::Neo4p::Query->new('MATCH (n) WHERE id(n) = {id} RETURN n');
   #  my $id = REST::Neo4p::Node->new()->id();
   #  $q->execute( id => $id );
   #  $q->fetch;
@@ -72,7 +72,7 @@ SKIP : {
   ok $n2, '2nd node' and push @cleanup, $n2;
   my $r = REST::Neo4p::Relationship->new( $n1 => $n2, 'TEST' );
   ok $r, 'new rel' and push @cleanup, $r;
-  $q = REST::Neo4p::Query->new('MATCH ()-[r]->() WHERE id(r) = $id RETURN r');
+  $q = REST::Neo4p::Query->new('MATCH ()-[r]->() WHERE id(r) = {id} RETURN r');
   $q->{RaiseError} = 1;
 
   eval {

--- a/t/id_roundtrip.t
+++ b/t/id_roundtrip.t
@@ -25,6 +25,7 @@ diag "Test server unavailable (".$not_connected->message.") : tests skipped" if 
 
 SKIP : {
   skip 'no local connection to neo4j', 34 if $not_connected;
+  skip 'MATCH query requires Neo4j 2 or later', 34 unless REST::Neo4p->_check_version(2,0,0,0);
 
   my $n1 = REST::Neo4p::Node->new();
   ok $n1, 'new node' and push @cleanup, $n1;

--- a/t/json_utf8.t
+++ b/t/json_utf8.t
@@ -3,7 +3,7 @@ use Test::More tests => 38;
 use Module::Build;
 use lib qw|../lib lib|;
 use lib 't/lib';
-use Neo4p::Connect;
+use Neo4p::Connect ':cypher_params_v2';
 use strict;
 use warnings;
 my @cleanup;
@@ -58,7 +58,7 @@ SKIP : {
   # ->get_properties worked as well
   # ->as_simple worked as well (probably via the entity cache)
 
-  my $q2 = REST::Neo4p::Query->new("MATCH (n) WHERE id(n) = \$id RETURN n", $id_param);
+  my $q2 = REST::Neo4p::Query->new("MATCH (n) WHERE id(n) = {id} RETURN n", $id_param);
   $q2->{ResponseAsObjects} = 0;
   $q2->execute;
   eval { $row = $q2->fetch };
@@ -70,7 +70,7 @@ SKIP : {
   # Node::simple_from_json_response
   $q2->finish;
 
-  my $q3 = REST::Neo4p::Query->new("MATCH (n) WHERE id(n) = \$id RETURN n." . (join ", n.", @keys), $id_param);
+  my $q3 = REST::Neo4p::Query->new("MATCH (n) WHERE id(n) = {id} RETURN n." . (join ", n.", @keys), $id_param);
   $q3->execute;
   eval { $row = $q3->fetch };
   ok $row, 'fetch node properties';
@@ -86,7 +86,7 @@ SKIP : {
   ok $r1, 'create rel' and push @cleanup, $r1;
   $id_param = { id => 0 + $r1->id };
   
-  my $q5 = REST::Neo4p::Query->new("MATCH ()-[r]-() WHERE id(r) = \$id RETURN r." . (join ", r.", @keys), $id_param);
+  my $q5 = REST::Neo4p::Query->new("MATCH ()-[r]-() WHERE id(r) = {id} RETURN r." . (join ", r.", @keys), $id_param);
   $q5->execute;
   eval { $row = $q5->fetch };
   ok $row, 'fetch rel properties';

--- a/t/json_utf8.t
+++ b/t/json_utf8.t
@@ -34,6 +34,7 @@ sub to_hex ($) {
 
 SKIP : {
   skip 'no local connection to neo4j', 37 if $not_connected;
+  skip 'MATCH query requires Neo4j 2 or later', 37 unless REST::Neo4p->_check_version(2,0,0,0);
 
   my %props = (
     singlebyte => "\N{U+0025}",  # '%' PERCENT SIGN = 0x25

--- a/t/lib/Neo4p/Connect.pm
+++ b/t/lib/Neo4p/Connect.pm
@@ -4,7 +4,7 @@ use REST::Neo4p;
 use strict;
 use warnings;
 
-our @EXPORT=qw/connect/;
+our @EXPORT=qw/connect neo4j_index_unavailable/;
 
 sub connect {
   my ($TEST_SERVER,$user,$pass) = @_;
@@ -25,3 +25,15 @@ sub connect {
     return $e;
   }
 }
+
+sub neo4j_index_unavailable {
+  return unless REST::Neo4p->connected;
+  return 'Neo4j 5 index syntax unimplemented' if REST::Neo4p->neo4j_version =~ /^5\./;
+  return if REST::Neo4p->neo4j_version =~ /^[014]\./;
+  return if REST::Neo4p->neo4j_version =~ /^3\.5\./;
+  # For Neo4j 2 and 3 (before 3.5), only native indexes are available.
+  return unless REST::Neo4p->agent->isa('REST::Neo4p::Agent::Neo4j::Driver');
+  return 'Neo4j::Driver uses fulltext index for emulation, which is only available starting from Neo4j 3.5';
+}
+
+1;

--- a/t/lib/Neo4p/Test.pm
+++ b/t/lib/Neo4p/Test.pm
@@ -69,7 +69,7 @@ sub find_sample {
   my ($k,$v) = @_;
   $v+=0 if looks_like_number $v;
   my $lbl = $self->lbl;
-  my $q = REST::Neo4p::Query->new("MATCH (n:$lbl) where n.$k = \$value return n");
+  my $q = REST::Neo4p::Query->new("MATCH (n:$lbl) where n.$k = {value} return n");
   $q->execute({value => $v});
   my @ret;
   while (my $r = $q->fetch) {
@@ -82,7 +82,7 @@ sub delete_sample {
   my $self = shift;
   die "No connection"  unless REST::Neo4p->connected;
   my $lbl = $self->lbl;
-  my $q = REST::Neo4p::Query->new("match (n:$lbl) where n.uuid = \$uuid detach delete n",{uuid => $self->uuid});
+  my $q = REST::Neo4p::Query->new("match (n:$lbl) where n.uuid = {uuid} detach delete n",{uuid => $self->uuid});
   $q->execute();
   return 1;
 }

--- a/t/rt_80150.t
+++ b/t/rt_80150.t
@@ -1,6 +1,6 @@
 #-*-perl-*-
 #$Id$
-use Test::More tests => 4;
+use Test::More;
 use Test::Exception;
 use Module::Build;
 use lib qw|../lib lib|;
@@ -19,15 +19,17 @@ eval {
     $pass = $build->notes('pass');
 };
 my $TEST_SERVER = $build ? $build->notes('test_server') : $ENV{REST_NEO4P_TEST_SERVER} // 'http://127.0.0.1:7474';
-my $num_live_tests = 3;
 
-use_ok('REST::Neo4p');
+use REST::Neo4p;
 
 my $not_connected = connect($TEST_SERVER,$user,$pass);
 diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
 
-SKIP : {
-  skip 'no local connection to neo4j', $num_live_tests if $not_connected;
+plan skip_all => neo4j_index_unavailable() if neo4j_index_unavailable();
+plan skip_all => 'no local connection to neo4j' if $not_connected;
+plan tests => 3;
+
+{
   ok my $idx = REST::Neo4p::Index->new('node', 'medicago_truncatula_3_5v5');
   is $idx->name('medicago_truncatula_3_5v5'), 'medicago_truncatula_3_5v5', 'index name is correct';
 

--- a/t/rt_81128.t
+++ b/t/rt_81128.t
@@ -29,6 +29,7 @@ diag "Test server unavailable (".$not_connected->message.") : tests skipped" if 
 
 SKIP : {
   skip 'no local connection to neo4j', $num_live_tests if $not_connected;
+  skip 'MATCH query requires Neo4j 2 or later', $num_live_tests unless REST::Neo4p->_check_version(2,0,0,0);
   
   ok my $n1 = REST::Neo4p::Node->new( {name => 'ricky'} ), 'new node 1';
   push @cleanup, $n1 if $n1;

--- a/t/rt_91640.t
+++ b/t/rt_91640.t
@@ -29,8 +29,8 @@ my $not_connected = connect($TEST_SERVER,$user,$pass);
 diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
 
 
-#SKIP : {
-#  skip "Neo4j server version >= 2.0.0-M02 required, skipping...", $num_live_tests unless  REST::Neo4p->_check_version(2,0,0,2);
+SKIP : {
+  skip "Neo4j server version >= 2.0.0-M02 required, skipping...", $num_live_tests unless REST::Neo4p->_check_version(2,0,0,2);
 
 my $neo4p = 'REST::Neo4p';
 my ($n, $m, $t);
@@ -80,9 +80,9 @@ STMT1
   is $$r[0]->get_property('utf8'), 'Сохранить', 'cyrillic property value retrieved correctly';
 
 }
-#}
 
   END {
     
     eval { $t && $t->delete_sample; };
   }
+}

--- a/t/rt_91640.t
+++ b/t/rt_91640.t
@@ -8,7 +8,7 @@ use lib 'lib';
 use lib 't/lib';
 use REST::Neo4p;
 use Neo4p::Test;
-use Neo4p::Connect;
+use Neo4p::Connect ':cypher_params_v2';
 use strict;
 use warnings;
 no warnings qw(once);

--- a/t/rt_91748.t
+++ b/t/rt_91748.t
@@ -1,5 +1,5 @@
 #$Id$
-use Test::More tests => 2;
+use Test::More;
 use Test::Exception;
 use Module::Build;
 use lib qw|../lib lib|;
@@ -20,13 +20,15 @@ eval {
     $pass = $build->notes('pass');
 };
 my $TEST_SERVER = $build ? $build->notes('test_server') : $ENV{REST_NEO4P_TEST_SERVER} // 'http://127.0.0.1:7474';
-my $num_live_tests = 2;
 
 my $not_connected = connect($TEST_SERVER,$user,$pass);
 diag "Test server unavailable (".$not_connected->message.") : tests skipped" if $not_connected;
 
-SKIP : {
-  skip 'no local connection to neo4j', $num_live_tests if $not_connected;
+plan skip_all => neo4j_index_unavailable() if neo4j_index_unavailable();
+plan skip_all => 'no local connection to neo4j' if $not_connected;
+plan tests => 2;
+
+{
   $index = REST::Neo4p::Index->new('node', $test_index); 
   lives_ok {
     $n = $index->create_unique(bar => "0", {bar => "0"})


### PR DESCRIPTION
Hi Mark @majensen,

I’ve been working on an update for Neo4j::Driver that is just about ready for release now. ([Neo4j-Driver-1.02-TRIAL](https://metacpan.org/release/AJNN/Neo4j-Driver-1.02-TRIAL)) The new version removes some old cruft, cutting lines of code by over 10 %. It also improves performance. One of these improvements is that values in the query result are now passed through directly from Neo4j::Bolt to the user. That change breaks use of the Bolt protocol with REST::Neo4p. (HTTP still works fine.)

This PR fixes that issue. It also contains several other fixes, including for problems in the REST::Neo4p tests related to very old and new Neo4j versions. However, the known problem with indices in Neo4j 5 still exists. https://github.com/majensen/rest-neo4p/issues/34#issuecomment-1446745909 This PR simply skips the associated tests on unsupported Neo4j versions.

This PR should make REST::Neo4p work *reasonably* well on all Neo4j versions in the range 1.9 through 5.26, and possibly beyond.

I understand you don’t plan on spending much time with REST::Neo4p going forward. But as long as it involves relatively little effort (such as merging these PRs and making a new release ☺️), I think there is value in keeping it working.